### PR TITLE
Add handler to serve any file's contents (not just html)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The old NuGet package has been unlisted and will not receive any updates any mor
     - [negotiate](#negotiate)
     - [negotiateWith](#negotiatewith)
     - [htmlFile](#htmlfile)
+    - [fileContent] (#fileContent)
     - [dotLiquid](#dotliquid)
     - [dotLiquidTemplate](#dotliquidtemplate)
     - [dotLiquidHtmlView](#dotliquidhtmlview)
@@ -632,6 +633,20 @@ This http handler takes a relative path of a html file as input parameter and se
 let app = 
     choose [
         route  "/" >=> htmlFile "index.html"
+    ]
+```
+### fileContent
+
+`fileContent` sets or modifies the body of the `HttpResponse` with the contents of a physical file. This http handler triggers a response to the client and other http handlers will not be able to modify the HTTP headers afterwards any more.
+
+This http handler takes a relative path of a file as input parameter and sets the HTTP header `Content-Type` to the content type provided as the first parameter.
+
+#### Example:
+
+```fsharp
+let app = 
+    choose [
+        routef  "/style" >=> fileContent "text/css" "mystyles.css"
     ]
 ```
 

--- a/src/Giraffe/Common.fs
+++ b/src/Giraffe/Common.fs
@@ -33,3 +33,12 @@ let readFileAsString (filePath : string) =
             reader.ReadToEndAsync()
             |> Async.AwaitTask
     }
+
+let readFileAsBytes (filePath : string) =
+    async {
+        use stream = new System.IO.FileStream(filePath, System.IO.FileMode.Open)
+        let length = (int) stream.Length
+        let result = Array.init length (fun _ -> (byte)0)
+        let! contents = stream.AsyncRead (result, 0, length)
+        return result
+    }

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -330,6 +330,20 @@ let htmlFile (relativeFilePath : string) =
                 >=> setBodyAsString html)
         }
 
+/// Reads a file from disk and writes its contents to the body of the HTTP response
+/// with a Content-Type provided.
+let fileContent (contentType: string) (relativeFilePath : string) =
+    fun (ctx : HttpHandlerContext) ->
+        async {
+            let env = ctx.Services.GetService<IHostingEnvironment>()
+            let filePath = env.ContentRootPath + relativeFilePath
+            let! contents = readFileAsBytes filePath     
+            return!
+                ctx
+                |> (setHttpHeader "Content-Type" contentType
+                >=> setBody contents)
+        }
+
 /// Renders a model and a template with the DotLiquid template engine and sets the HTTP response
 /// with the compiled output as well as the Content-Type HTTP header to the given value.
 let dotLiquid (contentType : string) (template : string) (model : obj) =


### PR DESCRIPTION
I added this functionality to my own sandbox project, and then thought that it would be generally useful.

It allows the dev to server the contents of any static file to the response with a given content header.  The htmlFile handler already exists, but doesn't allow me to serve images/styles/scripts/pdfs etc that are useful in a standard content-rich website.