### PR TITLE
Add support for full .NET framework

### DIFF
--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <AssemblyName>Giraffe</AssemblyName>
     <VersionPrefix>0.1.0-alpha015</VersionPrefix>
@@ -46,7 +47,5 @@
     <Compile Include="ModelBinding.fs" />
     <Compile Include="Middleware.fs" />
   </ItemGroup>
-
-
 
 </Project>

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>Giraffe</AssemblyName>
     <VersionPrefix>0.1.0-alpha015</VersionPrefix>
@@ -7,7 +6,7 @@
     <Copyright>Copyright 2017 Dustin Moris Gorski</Copyright>
     <NeutralLanguage>en-GB</NeutralLanguage>
     <Authors>Dustin Moris Gorski and contributors</Authors>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <DebugType>portable</DebugType>
     <WarningsAsErrors>1</WarningsAsErrors>
     <Optimize>True</Optimize>
@@ -47,5 +46,7 @@
     <Compile Include="ModelBinding.fs" />
     <Compile Include="Middleware.fs" />
   </ItemGroup>
+
+
 
 </Project>


### PR DESCRIPTION
Changing the target frameworks did the trick for #46 .
Not sure what will happen on the CI server.

Also creating an old school `fsproj ` console app and getting AspNetCore in general to work on it is a pain.
Some issues I came across:
- Libuv was not copied, see https://github.com/aspnet/KestrelHttpServer/issues/1652
- System.Numerics.Vectors gave a strange assemblyRedirect problem, I had to change my fsproj to
```xml
    <Reference Include="System.Numerics.Vectors">
   <HintPath>..\packages\System.Numerics.Vectors.4.3.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
      <Private>True</Private>
    </Reference>
```
See https://github.com/dotnet/corefx/issues/3103
And a redirect in app.config

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <startup>
    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
  </startup>
  <runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-4.99.0.0" newVersion="4.1.2.0" />
      </dependentAssembly>
    </assemblyBinding>
  </runtime>
</configuration>
```

In case anyone every tries to do the same. 