### PR TITLE
Task/Task<'T> Computation expression async bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ let routeStartsWith (subPath : string) =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         if ctx.Request.Path.ToString().StartsWith subPath
         then next ctx
-        else async.Return None
+        else Task.FromResult None
 ```
 
 Defining another custom HTTP handler to validate a mandatory HTTP header:
@@ -956,7 +956,7 @@ open Giraffe.HttpContextExtensions
 
 let submitCar =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             // Binds a JSON payload to a Car object
             let! car = ctx.BindJson<Car>()
 
@@ -1015,7 +1015,7 @@ open Giraffe.HttpContextExtensions
 
 let submitCar =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             // Binds an XML payload to a Car object
             let! car = ctx.BindXml<Car>()
 
@@ -1079,7 +1079,7 @@ open Giraffe.HttpContextExtensions
 
 let submitCar =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             // Binds a form urlencoded payload to a Car object
             let! car = ctx.BindForm<Car>()
 
@@ -1138,7 +1138,7 @@ open Giraffe.HttpContextExtensions
 
 let submitCar =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             // Binds a query string to a Car object
             let car = ctx.BindQueryString<Car>()
 
@@ -1193,7 +1193,7 @@ open Giraffe.HttpContextExtensions
 
 let submitCar =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             // Binds a JSON, XML or form urlencoded payload to a Car object
             let! car = ctx.BindModel<Car>()
 

--- a/samples/SampleApp/SampleApp.Tests/Tests.fs
+++ b/samples/SampleApp/SampleApp.Tests/Tests.fs
@@ -93,8 +93,9 @@ let ``Test /error returns status code 500`` () =
     get client "/error"
     |> isStatus HttpStatusCode.InternalServerError
     |> readText
-    |> shouldEqual "One or more errors occurred. (Something went wrong!)"
-
+    //|> shouldEqual "One or more errors occurred. (Something went wrong!)"
+    |> shouldEqual "Something went wrong!"
+    
 [<Fact>]
 let ``Test /user returns error when not logged in`` () =
     use server = new TestServer(createHost())

--- a/samples/SampleApp/SampleApp/Program.fs
+++ b/samples/SampleApp/SampleApp/Program.fs
@@ -11,6 +11,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Http.Features
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
+open Giraffe.Tasks
 open Giraffe.HttpContextExtensions
 open Giraffe.HttpHandlers
 open Giraffe.Middleware
@@ -43,7 +44,7 @@ let mustBeAdmin =
 
 let loginHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let issuer = "http://localhost:5000"
             let claims =
                 [
@@ -54,7 +55,7 @@ let loginHandler =
             let identity = ClaimsIdentity(claims, authScheme)
             let user     = ClaimsPrincipal(identity)
 
-            do! ctx.Authentication.SignInAsync(authScheme, user) |> Async.AwaitTask
+            do! ctx.Authentication.SignInAsync(authScheme, user)
 
             return! text "Successfully logged in" next ctx
         }
@@ -80,14 +81,14 @@ type Car =
 
 let submitCar =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let! car = ctx.BindModel<Car>()
             return! json car next ctx
         }
 
 let smallFileUploadHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             return!
                 (match ctx.Request.HasFormContentType with
                 | false -> setStatusCode 400 >=> text "Bad request"
@@ -99,9 +100,9 @@ let smallFileUploadHandler =
 
 let largeFileUploadHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let formFeature = ctx.Features.Get<IFormFeature>()
-            let! form = formFeature.ReadFormAsync CancellationToken.None |> Async.AwaitTask
+            let! form = formFeature.ReadFormAsync CancellationToken.None
             return!
                 (form.Files
                 |> Seq.fold (fun acc file -> sprintf "%s\n%s" acc file.FileName) ""

--- a/src/Giraffe.DotLiquid/HttpHandlers.fs
+++ b/src/Giraffe.DotLiquid/HttpHandlers.fs
@@ -9,13 +9,14 @@ open Microsoft.Extensions.Primitives
 open DotLiquid
 open Giraffe.Common
 open Giraffe.HttpHandlers
+open Giraffe.Tasks
 
 /// Renders a model and a template with the DotLiquid template engine and sets the HTTP response
 /// with the compiled output as well as the Content-Type HTTP header to the given value.
 let dotLiquid (contentType : string) (template : string) (model : obj) : HttpHandler =
     let view = Template.Parse template
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let bytes =
                 model
                 |> Hash.FromAnonymousObject
@@ -29,7 +30,7 @@ let dotLiquid (contentType : string) (template : string) (model : obj) : HttpHan
 /// the compiled output as well as the given contentType as the HTTP reponse.
 let dotLiquidTemplate (contentType : string) (templatePath : string) (model : obj) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let env = ctx.RequestServices.GetService<IHostingEnvironment>()
             let path = env.ContentRootPath + templatePath
             let! template = readFileAsString path

--- a/src/Giraffe.Razor/HttpHandlers.fs
+++ b/src/Giraffe.Razor/HttpHandlers.fs
@@ -6,6 +6,7 @@ open Microsoft.AspNetCore.Mvc.Razor
 open Microsoft.AspNetCore.Mvc.ViewFeatures
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Primitives
+open Giraffe.Tasks
 open Giraffe.HttpHandlers
 open Giraffe.Razor.Engine
 
@@ -13,7 +14,7 @@ open Giraffe.Razor.Engine
 /// the compiled output as the HTTP reponse with the given contentType.
 let razorView (contentType : string) (viewName : string) (model : 'T) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let engine = ctx.RequestServices.GetService<IRazorViewEngine>()
             let tempDataProvider = ctx.RequestServices.GetService<ITempDataProvider>()
             let! result = renderRazorView engine tempDataProvider ctx viewName model

--- a/src/Giraffe.Razor/RazorEngine.fs
+++ b/src/Giraffe.Razor/RazorEngine.fs
@@ -10,13 +10,14 @@ open Microsoft.AspNetCore.Mvc.Razor
 open Microsoft.AspNetCore.Mvc.Rendering
 open Microsoft.AspNetCore.Mvc.ViewFeatures
 open Microsoft.AspNetCore.Routing
+open Giraffe.Tasks
 
 let renderRazorView (razorViewEngine   : IRazorViewEngine)
                     (tempDataProvider  : ITempDataProvider)
                     (httpContext       : HttpContext)
                     (viewName          : string)
                     (model             : 'T) =
-    async {
+    task {
         let actionContext    = ActionContext(httpContext, RouteData(), ActionDescriptor())
         let viewEngineResult = razorViewEngine.FindView(actionContext, viewName, false)
 
@@ -31,6 +32,6 @@ let renderRazorView (razorViewEngine   : IRazorViewEngine)
             let htmlHelperOptions  = HtmlHelperOptions()
             use output = new StringWriter()
             let viewContext = ViewContext(actionContext, view, viewDataDict, tempDataDict, output, htmlHelperOptions)
-            do! view.RenderAsync(viewContext) |> Async.AwaitTask
+            do! view.RenderAsync(viewContext)
             return Ok (output.ToString())
     }

--- a/src/Giraffe/Common.fs
+++ b/src/Giraffe/Common.fs
@@ -17,12 +17,10 @@ let inline strOption (str : string) =
     if String.IsNullOrEmpty str then None else Some str
 
 let readFileAsString (filePath : string) =
-    async {
+    task {
         use stream = new FileStream(filePath, FileMode.Open)
         use reader = new StreamReader(stream)
-        return!
-            reader.ReadToEndAsync()
-            |> Async.AwaitTask
+        return! reader.ReadToEndAsync()
     }
 
 /// ---------------------------

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="Tasks.fs" />
     <Compile Include="Common.fs" />
     <Compile Include="ComputationExpressions.fs" />
     <Compile Include="FormatExpressions.fs" />

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -53,27 +53,27 @@ type HttpContext with
     /// ---------------------------
 
     member this.ReadBodyFromRequest() =
-        async {
+        task {
             let body = this.Request.Body
             use reader = new StreamReader(body, true)
-            return! reader.ReadToEndAsync() |> Async.AwaitTask
+            return! reader.ReadToEndAsync()
         }
 
     member this.BindJson<'T>() =
-        async {
+        task {
             let! body = this.ReadBodyFromRequest()
             return deserializeJson<'T> body
         }
 
     member this.BindXml<'T>() =
-        async {
+        task {
             let! body = this.ReadBodyFromRequest()
             return deserializeXml<'T> body
         }
 
     member this.BindForm<'T>() =
-        async {
-            let! form = this.Request.ReadFormAsync() |> Async.AwaitTask
+        task {
+            let! form = this.Request.ReadFormAsync()
             let obj   = Activator.CreateInstance<'T>()
             let props = obj.GetType().GetProperties(BindingFlags.Instance ||| BindingFlags.Public)
             props
@@ -130,7 +130,7 @@ type HttpContext with
         obj
 
     member this.BindModel<'T>() =
-        async {
+        task {
             let method = this.Request.Method
             if method.Equals "POST" || method.Equals "PUT" then
                 let original = this.Request.ContentType

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -3,6 +3,7 @@ module Giraffe.HttpHandlers
 open System
 open System.Text
 open System.Collections.Generic
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Primitives
@@ -14,8 +15,9 @@ open Giraffe.FormatExpressions
 open Giraffe.XmlViewEngine
 open System.Text.RegularExpressions
 open Newtonsoft.Json.Linq
+open Giraffe.Tasks
 
-type HttpFuncResult = Async<HttpContext option>
+type HttpFuncResult = Task<HttpContext option>
 type HttpFunc       = HttpContext -> HttpFuncResult
 type HttpHandler    = HttpFunc  -> HttpFunc
 type ErrorHandler   = exn -> ILogger -> HttpHandler
@@ -45,7 +47,7 @@ let private getPath (ctx : HttpContext) =
 
 let private handlerWithRootedPath (path : string) (handler : HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let savedSubPath = getSavedSubPath ctx
             try
                 ctx.Items.Item RouteKey <- ((savedSubPath |> Option.defaultValue "") + path)
@@ -73,26 +75,32 @@ let compose (handler1 : HttpHandler) (handler2 : HttpHandler) : HttpHandler =
 /// See compose for more information.
 let (>=>) = compose
 
-/// Iterates through a list of HttpHandler functions and returns the
-/// result of the first HttpHandler which outcome is Some HttpContext
-let rec choose (handlers : HttpHandler list) : HttpHandler =
-    fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
-            match handlers with
+let rec private subChoose (funcs : HttpFunc list) : HttpFunc =
+    fun (ctx : HttpContext) ->
+        task {
+            match funcs with
             | [] -> return None
-            | handler :: tail ->
-                let! result = handler next ctx
+            | func :: tail ->
+                let! result = func ctx
                 match result with
                 | Some c -> return Some c
-                | None   -> return! choose tail next ctx
+                | None   -> return! subChoose tail ctx
         }
+
+/// Iterates through a list of HttpHandler functions and returns the
+/// result of the first HttpHandler which outcome is Some HttpContext
+let choose (handlers : HttpHandler list) : HttpHandler =
+    fun (next : HttpFunc) ->
+        let funcs = handlers |> List.map (fun h -> h next)
+        fun (ctx : HttpContext) ->
+            subChoose funcs ctx
 
 /// Filters an incoming HTTP request based on the HTTP verb
 let httpVerb (verb : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         if ctx.Request.Method.Equals verb
         then next ctx
-        else async.Return None
+        else Task.FromResult None
 
 let GET    : HttpHandler = httpVerb "GET"
 let POST   : HttpHandler = httpVerb "POST"
@@ -110,23 +118,23 @@ let mustAccept (mimeTypes : string list) : HttpHandler =
         |> Seq.exists (fun h -> mimeTypes |> Seq.contains h)
         |> function
             | true  -> next ctx
-            | false -> async.Return None
+            | false -> Task.FromResult None
 
 /// Challenges the client to authenticate with a given authentication scheme.
 let challenge (authScheme : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let auth = ctx.Authentication
-            do! auth.ChallengeAsync authScheme |> Async.AwaitTask
+            do! auth.ChallengeAsync authScheme
             return! next ctx
         }
 
 /// Signs off the current user.
 let signOff (authScheme : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let auth = ctx.Authentication
-            do! auth.SignOutAsync authScheme |> Async.AwaitTask
+            do! auth.SignOutAsync authScheme
             return! next ctx
         }
 
@@ -169,7 +177,7 @@ let route (path : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         if (getPath ctx).Equals path
         then next ctx
-        else async.Return None
+        else Task.FromResult None
 
 /// Filters an incoming HTTP request based on the request path (case sensitive).
 /// The arguments from the format string will be automatically resolved when the
@@ -178,7 +186,7 @@ let routef (path : StringFormat<_, 'T>) (routeHandler : 'T -> HttpHandler) : Htt
     fun (next : HttpFunc) (ctx : HttpContext) ->
         tryMatchInput path (getPath ctx) false
         |> function
-            | None      -> async.Return None
+            | None      -> Task.FromResult None
             | Some args -> routeHandler args next ctx
 
 /// Filters an incoming HTTP request based on the request path (case insensitive).
@@ -186,7 +194,7 @@ let routeCi (path : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         if String.Equals(getPath ctx, path, StringComparison.CurrentCultureIgnoreCase)
         then next ctx
-        else async.Return None
+        else Task.FromResult None
 
 /// Filters an incoming HTTP request based on the request path (case insensitive).
 /// The arguments from the format string will be automatically resolved when the
@@ -195,7 +203,7 @@ let routeCif (path : StringFormat<_, 'T>) (routeHandler : 'T -> HttpHandler) : H
     fun (next : HttpFunc) (ctx : HttpContext) ->
         tryMatchInput path (getPath ctx) true
         |> function
-            | None      -> async.Return None
+            | None      -> Task.FromResult None
             | Some args -> routeHandler args next ctx
 
 /// Filters an incoming HTTP request based on the request path (case insensitive).
@@ -218,21 +226,21 @@ let routeBind<'T> (route: string) (routeHandler : 'T -> HttpHandler) : HttpHandl
                 |> JObject.FromObject
                 |> fun jo -> jo.ToObject<'T>()
             routeHandler o next ctx
-        | _ -> async.Return None
+        | _ -> Task.FromResult None
 
 /// Filters an incoming HTTP request based on the beginning of the request path (case sensitive).
 let routeStartsWith (subPath : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         if (getPath ctx).StartsWith subPath
         then next ctx
-        else async.Return None
+        else Task.FromResult None
 
 /// Filters an incoming HTTP request based on the beginning of the request path (case insensitive).
 let routeStartsWithCi (subPath : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         if (getPath ctx).StartsWith(subPath, StringComparison.CurrentCultureIgnoreCase)
         then next ctx
-        else async.Return None
+        else Task.FromResult None
 
 /// Filters an incoming HTTP request based on a part of the request path (case sensitive).
 /// Subsequent route handlers inside the given handler function should omit the already validated path.
@@ -261,9 +269,9 @@ let setHttpHeader (key : string) (value : obj) : HttpHandler =
 /// Writes to the body of the HTTP response and sets the HTTP header Content-Length accordingly.
 let setBody (bytes : byte array) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             ctx.Response.Headers.["Content-Length"] <- StringValues(bytes.Length.ToString())
-            do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length) |> Async.AwaitTask
+            do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
             return! next ctx
         }
 
@@ -294,7 +302,7 @@ let xml (dataObj : obj) : HttpHandler =
 /// with a Content-Type of text/html.
 let htmlFile (relativeFilePath : string) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        async {
+        task {
             let env = ctx.GetService<IHostingEnvironment>()
             let filePath = env.ContentRootPath + relativeFilePath
             let! html = readFileAsString filePath

--- a/src/Giraffe/Tasks.fs
+++ b/src/Giraffe/Tasks.fs
@@ -1,0 +1,284 @@
+// Task.fs - TPL task computation expressions for F#
+//
+// Written in 2016 by Robert Peele (humbobst@gmail.com)
+//
+// To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights
+// to this software to the public domain worldwide. This software is distributed without any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+namespace Giraffe
+open System
+open System.Threading.Tasks
+open System.Runtime.CompilerServices
+
+// This module is not really obsolete, but it's not intended to be referenced directly from user code.
+// However, it can't be private because it is used within inline functions that *are* user-visible.
+// Marking it as obsolete is a workaround to hide it from auto-completion tools.
+[<Obsolete>]
+module TaskBuilder =
+    /// Represents the state of a computation:
+    /// either awaiting something with a continuation,
+    /// or completed with a return value.
+    type Step<'a> =
+        | Await of ICriticalNotifyCompletion * (unit -> Step<'a>)
+        | Return of 'a
+        /// We model tail calls explicitly, but still can't run them without O(n) memory usage.
+        | ReturnFrom of 'a Task
+    /// Implements the machinery of running a `Step<'m, 'm>` as a task returning a continuation task.
+    and StepStateMachine<'a>(firstStep) as this =
+        let methodBuilder = AsyncTaskMethodBuilder<'a Task>()
+        /// The continuation we left off awaiting on our last MoveNext().
+        let mutable continuation = fun () -> firstStep
+        /// Returns next pending awaitable or null if exiting (including tail call).
+        let nextAwaitable() =
+            try
+                match continuation() with
+                | Return r ->
+                    methodBuilder.SetResult(Task.FromResult(r))
+                    null
+                | ReturnFrom t ->
+                    methodBuilder.SetResult(t)
+                    null
+                | Await (await, next) ->
+                    continuation <- next
+                    await
+            with
+            | exn ->
+                methodBuilder.SetException(exn)
+                null
+        let mutable self = this
+
+        /// Start execution as a `Task<Task<'a>>`.
+        member __.Run() =
+            methodBuilder.Start(&self)
+            methodBuilder.Task
+    
+        interface IAsyncStateMachine with
+            /// Proceed to one of three states: result, failure, or awaiting.
+            /// If awaiting, MoveNext() will be called again when the awaitable completes.
+            member __.MoveNext() =
+                let mutable await = nextAwaitable()
+                if not (isNull await) then
+                    // Tell the builder to call us again when this thing is done.
+                    methodBuilder.AwaitUnsafeOnCompleted(&await, &self)    
+            member __.SetStateMachine(_) = () // Doesn't really apply since we're a reference type.
+
+    let unwrapException (agg : AggregateException) =
+        let inners = agg.InnerExceptions
+        if inners.Count = 1 then inners.[0]
+        else agg :> Exception
+
+    /// Used to represent no-ops like the implicit empty "else" branch of an "if" expression.
+    let zero = Return ()
+
+    /// Used to return a value.
+    let inline ret (x : 'a) = Return x
+
+    type Binder<'out> =
+        // We put the output generic parameter up here at the class level, so it doesn't get subject to
+        // inline rules. If we put it all in the inline function, then the compiler gets confused at the
+        // below and demands that the whole function either is limited to working with (x : obj), or must
+        // be inline itself.
+        //
+        // let yieldThenReturn (x : 'a) =
+        //     task {
+        //         do! Task.Yield()
+        //         return x
+        //     }
+
+        static member inline GenericAwait< ^abl, ^awt, ^inp
+                                            when ^abl : (member GetAwaiter : unit -> ^awt)
+                                            and ^awt :> ICriticalNotifyCompletion 
+                                            and ^awt : (member get_IsCompleted : unit -> bool)
+                                            and ^awt : (member GetResult : unit -> ^inp) >
+            (abl : ^abl, continuation : ^inp -> 'out Step) : 'out Step =
+                let awt = (^abl : (member GetAwaiter : unit -> ^awt)(abl)) // get an awaiter from the awaitable
+                if (^awt : (member get_IsCompleted : unit -> bool)(awt)) then // shortcut to continue immediately
+                    continuation (^awt : (member GetResult : unit -> ^inp)(awt))
+                else
+                    Await (awt, fun () -> continuation (^awt : (member GetResult : unit -> ^inp)(awt)))
+
+        static member inline GenericAwaitConfigureFalse< ^tsk, ^abl, ^awt, ^inp
+                                                        when ^tsk : (member ConfigureAwait : bool -> ^abl)
+                                                        and ^abl : (member GetAwaiter : unit -> ^awt)
+                                                        and ^awt :> ICriticalNotifyCompletion 
+                                                        and ^awt : (member get_IsCompleted : unit -> bool)
+                                                        and ^awt : (member GetResult : unit -> ^inp) >
+            (tsk : ^tsk, continuation : ^inp -> 'out Step) : 'out Step =
+                let abl = (^tsk : (member ConfigureAwait : bool -> ^abl)(tsk, false))
+                Binder<'out>.GenericAwait(abl, continuation)
+
+    /// Special case of the above for `Task<'a>`. Have to write this out by hand to avoid confusing the compiler
+    /// trying to decide between satisfying the constraints with `Task` or `Task<'a>`.
+    let inline bindTask (task : 'a Task) (continuation : 'a -> Step<'b>) =
+        let awt = task.GetAwaiter()
+        if awt.IsCompleted then // Proceed to the next step based on the result we already have.
+            continuation(awt.GetResult())
+        else // Await and continue later when a result is available.
+            Await (awt, (fun () -> continuation(awt.GetResult())))
+
+    /// Special case of the above for `Task<'a>`, for the context-insensitive builder.
+    /// Have to write this out by hand to avoid confusing the compiler thinking our built-in bind method
+    /// defined on the builder has fancy generic constraints on inp and out parameters.
+    let inline bindTaskConfigureFalse (task : 'a Task) (continuation : 'a -> Step<'b>) =
+        let awt = task.ConfigureAwait(false).GetAwaiter()
+        if awt.IsCompleted then // Proceed to the next step based on the result we already have.
+            continuation(awt.GetResult())
+        else // Await and continue later when a result is available.
+            Await (awt, (fun () -> continuation(awt.GetResult())))
+
+    /// Chains together a step with its following step.
+    /// Note that this requires that the first step has no result.
+    /// This prevents constructs like `task { return 1; return 2; }`.
+    let rec combine (step : Step<unit>) (continuation : unit -> Step<'b>) =
+        match step with
+        | Return _ -> continuation()
+        | ReturnFrom t ->
+            Await (t.GetAwaiter(), continuation)
+        | Await (awaitable, next) ->
+            Await (awaitable, fun () -> combine (next()) continuation)
+
+    /// Builds a step that executes the body while the condition predicate is true.
+    let whileLoop (cond : unit -> bool) (body : unit -> Step<unit>) =
+        if cond() then
+            // Create a self-referencing closure to test whether to repeat the loop on future iterations.
+            let rec repeat () =
+                if cond() then
+                    let body = body()
+                    match body with
+                    | Return _ -> repeat()
+                    | ReturnFrom t -> Await(t.GetAwaiter(), repeat)
+                    | Await (awaitable, next) ->
+                        Await (awaitable, fun () -> combine (next()) repeat)
+                else zero
+            // Run the body the first time and chain it to the repeat logic.
+            combine (body()) repeat
+        else zero
+
+    /// Wraps a step in a try/with. This catches exceptions both in the evaluation of the function
+    /// to retrieve the step, and in the continuation of the step (if any).
+    let rec tryWith(step : unit -> Step<'a>) (catch : exn -> Step<'a>) =
+        try
+            match step() with
+            | Return _ as i -> i
+            | ReturnFrom t ->
+                let awaitable = t.GetAwaiter()
+                Await(awaitable, fun () ->
+                    try
+                        awaitable.GetResult() |> Return
+                    with
+                    | exn -> catch exn)
+            | Await (awaitable, next) -> Await (awaitable, fun () -> tryWith next catch)
+        with
+        | exn -> catch exn
+
+    /// Wraps a step in a try/finally. This catches exceptions both in the evaluation of the function
+    /// to retrieve the step, and in the continuation of the step (if any).
+    let rec tryFinally (step : unit -> Step<'a>) fin =
+        let step =
+            try step()
+            // Important point: we use a try/with, not a try/finally, to implement tryFinally.
+            // The reason for this is that if we're just building a continuation, we definitely *shouldn't*
+            // execute the `fin()` part yet -- the actual execution of the asynchronous code hasn't completed!
+            with
+            | _ ->
+                fin()
+                reraise()
+        match step with
+        | Return _ as i ->
+            fin()
+            i
+        | ReturnFrom t ->
+            let awaitable = t.GetAwaiter()
+            Await(awaitable, fun () ->
+                try
+                    awaitable.GetResult() |> Return
+                with
+                | _ ->
+                    fin()
+                    reraise())
+        | Await (awaitable, next) ->
+            Await (awaitable, fun () -> tryFinally next fin)
+
+    /// Implements a using statement that disposes `disp` after `body` has completed.
+    let inline using (disp : #IDisposable) (body : _ -> Step<'a>) =
+        // A using statement is just a try/finally with the finally block disposing if non-null.
+        tryFinally
+            (fun () -> body disp)
+            (fun () -> if not (isNull (box disp)) then disp.Dispose())
+
+    /// Implements a loop that runs `body` for each element in `sequence`.
+    let forLoop (sequence : 'a seq) (body : 'a -> Step<unit>) =
+        // A for loop is just a using statement on the sequence's enumerator...
+        using (sequence.GetEnumerator())
+            // ... and its body is a while loop that advances the enumerator and runs the body on each element.
+            (fun e -> whileLoop e.MoveNext (fun () -> body e.Current))
+
+    /// Runs a step as a task -- with a short-circuit for immediately completed steps.
+    let run (firstStep : unit -> Step<'a>) =
+        try
+            match firstStep() with
+            | Return x -> Task.FromResult(x)
+            | ReturnFrom t -> t
+            | Await _ as step -> StepStateMachine<'a>(step).Run().Unwrap() // sadly can't do tail recursion
+        // Any exceptions should go on the task, rather than being thrown from this call.
+        // This matches C# behavior where you won't see an exception until awaiting the task,
+        // even if it failed before reaching the first "await".
+        with
+        | exn ->
+            let src = new TaskCompletionSource<_>()
+            src.SetException(exn)
+            src.Task
+
+
+    type ContextInsensitiveTaskBuilder() =
+        // These methods are consistent between the two builders.
+        // Unfortunately, inline members do not work with inheritance.
+        member inline __.Delay(f : unit -> Step<_>) = f
+        member inline __.Run(f : unit -> Step<'m>) = run f
+        member inline __.Zero() = zero
+        member inline __.Return(x) = ret x
+        member inline __.ReturnFrom(task : _ Task) = ReturnFrom task
+        member inline __.Combine(step : unit Step, continuation) = combine step continuation
+        member inline __.While(condition : unit -> bool, body : unit -> unit Step) = whileLoop condition body
+        member inline __.For(sequence : _ seq, body : _ -> unit Step) = forLoop sequence body
+        member inline __.TryWith(body : unit -> _ Step, catch : exn -> _ Step) = tryWith body catch
+        member inline __.TryFinally(body : unit -> _ Step, fin : unit -> unit) = tryFinally body fin
+        member inline __.Using(disp : #IDisposable, body : #IDisposable -> _ Step) = using disp body
+        // End of consistent methods -- the following methods are different between
+        // `TaskBuilder` and `ContextInsensitiveTaskBuilder`!
+
+        // We have to have a dedicated overload for Task<'a> so the compiler doesn't get confused.
+        // Everything else can use bindGenericAwaitable via an extension member (defined later).
+        member inline __.Bind(task : 'a Task, continuation : 'a -> 'b Step) : 'b Step =
+            bindTaskConfigureFalse task continuation
+
+// Don't warn about our use of the "obsolete" module we just defined (see notes at start of file).
+#nowarn "44"
+
+[<AutoOpen>]
+module Tasks =
+    /// Builds a `System.Threading.Tasks.Task<'a>` similarly to a C# async/await method, but with
+    /// all awaited tasks automatically configured *not* to resume on the captured context.
+    /// This is often preferable when writing library code that is not context-aware, but undesirable when writing
+    /// e.g. code that must interact with user interface controls on the same thread as its caller.
+    let task = TaskBuilder.ContextInsensitiveTaskBuilder()
+
+    // These are fallbacks when the Bind and ReturnFrom on the builder object itself don't apply.
+    // This is how we support binding arbitrary task-like types.
+    type TaskBuilder.ContextInsensitiveTaskBuilder with
+        member inline this.ReturnFrom(taskLike) =
+            TaskBuilder.Binder<_>.GenericAwait(taskLike, TaskBuilder.ret)
+        member inline this.Bind(taskLike, continuation : _ -> 'a TaskBuilder.Step) : 'a TaskBuilder.Step =
+            TaskBuilder.Binder<'a>.GenericAwait(taskLike, continuation)
+    
+    [<AutoOpen>]
+    module HigherPriorityBinds =
+        // When it's possible for these to work, the compiler should prefer them since they shadow the ones above.
+        type TaskBuilder.ContextInsensitiveTaskBuilder with
+            member inline this.ReturnFrom(configurableTaskLike) =
+                TaskBuilder.Binder<_>.GenericAwaitConfigureFalse(configurableTaskLike, TaskBuilder.ret)
+            member inline this.Bind(configurableTaskLike, continuation : _ -> 'a TaskBuilder.Step) : 'a TaskBuilder.Step =
+                TaskBuilder.Binder<'a>.GenericAwaitConfigureFalse(configurableTaskLike, continuation)

--- a/src/Giraffe/Tasks.fs
+++ b/src/Giraffe/Tasks.fs
@@ -1,4 +1,4 @@
-// Task.fs - TPL task computation expressions for F#
+// Tasks.fs - TPL task computation expressions for F#
 //
 // Written in 2016 by Robert Peele (humbobst@gmail.com)
 //

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -740,13 +740,14 @@ let ``GET "/api/test" returns "test"`` () =
         let app =
             GET >=> choose [
                 route "/"    >=> text "Hello World"
-                route "/foo" >=> text "bar"
+                //route "/foo" >=> text "bar"
                 subRoute "/api" (
                     choose [
                         route ""       >=> text "api root"
                         route "/admin" >=> text "admin"
                         route "/users" >=> text "users" ] )
-                route "/api/test" >=> text "test"
+                route "/foo" >=> text "bar"
+                route "/api/test" >=> text "test" //repositioned
                 setStatusCode 404 >=> text "Not found" ]
 
         let handler = app next

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -4,6 +4,7 @@ open System
 open System.Collections.Generic
 open System.IO
 open System.Text
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Primitives
@@ -15,6 +16,7 @@ open Giraffe.Middleware
 open Giraffe.XmlViewEngine
 open Giraffe.DotLiquid.HttpHandlers
 open Giraffe.Tests.Asserts
+open Giraffe.Tasks
 
 // ---------------------------------
 // Helper functions
@@ -37,7 +39,7 @@ let assertFailf format args =
     let msg = sprintf format args
     Assert.True(false, msg)
 
-let next : HttpFunc = Some >> async.Return
+let next : HttpFunc = Some >> Task.FromResult
 
 // ---------------------------------
 // Test Types
@@ -86,15 +88,15 @@ let ``GET "/" returns "Hello World"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "Hello World"
 
-    let result =
-        app next ctx
-        |> Async.RunSynchronously
+    task { 
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/foo" returns "bar"`` () =
@@ -110,16 +112,15 @@ let ``GET "/foo" returns "bar"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "bar"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task { 
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/FOO" returns 404 "Not found"`` () =
@@ -135,10 +136,8 @@ let ``GET "/FOO" returns 404 "Not found"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "Not found"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -146,6 +145,7 @@ let ``GET "/FOO" returns 404 "Not found"`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal(404, ctx.Response.StatusCode)
+    }
 
 [<Fact>]
 let ``GET "/json" returns json object`` () =
@@ -162,16 +162,15 @@ let ``GET "/json" returns json object`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "{\"Foo\":\"john\",\"Bar\":\"doe\",\"Age\":30}"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``POST "/post/1" returns "1"`` () =
@@ -191,16 +190,15 @@ let ``POST "/post/1" returns "1"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "1"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``POST "/post/2" returns "2"`` () =
@@ -220,16 +218,15 @@ let ``POST "/post/2" returns "2"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "2"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``PUT "/post/2" returns 404 "Not found"`` () =
@@ -249,10 +246,8 @@ let ``PUT "/post/2" returns 404 "Not found"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "Not found"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -260,6 +255,7 @@ let ``PUT "/post/2" returns 404 "Not found"`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal(404, ctx.Response.StatusCode)
+    }
 
 [<Fact>]
 let ``GET "/dotLiquid" returns rendered html view`` () =
@@ -285,10 +281,8 @@ let ``GET "/dotLiquid" returns rendered html view`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "<html><head><title>DotLiquid</title></head><body><p>John Doe is 30 years old.</p></body></html>"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -296,6 +290,7 @@ let ``GET "/dotLiquid" returns rendered html view`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("text/html", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``POST "/text" with supported Accept header returns "good"`` () =
@@ -319,10 +314,8 @@ let ``POST "/text" with supported Accept header returns "good"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "text"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -330,6 +323,7 @@ let ``POST "/text" with supported Accept header returns "good"`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("text/plain", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``POST "/json" with supported Accept header returns "json"`` () =
@@ -353,10 +347,8 @@ let ``POST "/json" with supported Accept header returns "json"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "\"json\""
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -364,6 +356,7 @@ let ``POST "/json" with supported Accept header returns "json"`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("application/json", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``POST "/either" with supported Accept header returns "either"`` () =
@@ -387,10 +380,8 @@ let ``POST "/either" with supported Accept header returns "either"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "either"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -398,6 +389,7 @@ let ``POST "/either" with supported Accept header returns "either"`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("text/plain", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``POST "/either" with unsupported Accept header returns 404 "Not found"`` () =
@@ -421,10 +413,8 @@ let ``POST "/either" with unsupported Accept header returns 404 "Not found"`` ()
     ctx.Response.Body <- new MemoryStream()
     let expected = "Not found"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
@@ -432,6 +422,7 @@ let ``POST "/either" with unsupported Accept header returns 404 "Not found"`` ()
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal(404, ctx.Response.StatusCode)
+    }
 
 [<Fact>]
 let ``GET "/JSON" returns "BaR"`` () =
@@ -449,17 +440,17 @@ let ``GET "/JSON" returns "BaR"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "BaR"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task { 
+        let! result = app next ctx
+        //|> Async.RunSynchronously
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
-
+    }
+    
 [<Fact>]
 let ``GET "/foo/blah blah/bar" returns "blah blah"`` () =
     let ctx = Substitute.For<HttpContext>()
@@ -476,16 +467,15 @@ let ``GET "/foo/blah blah/bar" returns "blah blah"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "blah%20blah"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/foo/johndoe/59" returns "Name: johndoe, Age: 59"`` () =
@@ -503,16 +493,15 @@ let ``GET "/foo/johndoe/59" returns "Name: johndoe, Age: 59"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "Name: johndoe, Age: 59"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``POST "/POsT/1" returns "1"`` () =
@@ -531,16 +520,15 @@ let ``POST "/POsT/1" returns "1"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "1"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None     -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``POST "/POsT/523" returns "523"`` () =
@@ -559,16 +547,15 @@ let ``POST "/POsT/523" returns "523"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "523"
 
-    let result =
+    task {
+        let! result = app next ctx
 
-        app next ctx
-        |> Async.RunSynchronously
-
-    match result with
-    | None     -> assertFailf "Result was expected to be %s" expected
-    | Some ctx ->
-        let body = getBody ctx
-        Assert.Equal(expected, body)
+        match result with
+        | None     -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/api" returns "api root"`` () =
@@ -591,16 +578,15 @@ let ``GET "/api" returns "api root"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "api root"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/api/users" returns "users"`` () =
@@ -623,48 +609,17 @@ let ``GET "/api/users" returns "users"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "users"
 
-    let result =
+    task {
+        let! result = app next ctx
 
-        app next ctx
-        |> Async.RunSynchronously
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+    }
 
-    match result with
-    | None -> assertFailf "Result was expected to be %s" expected
-    | Some ctx ->
-        let body = getBody ctx
-        Assert.Equal(expected, body)
-
-[<Fact>]
-let ``GET "/api/test" returns "test"`` () =
-    let ctx = Substitute.For<HttpContext>()
-    let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route ""       >=> text "api root"
-                    route "/admin" >=> text "admin"
-                    route "/users" >=> text "users" ] )
-            route "/api/test" >=> text "test"
-            setStatusCode 404 >=> text "Not found" ]
-
-    ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
-    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
-    ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/test")) |> ignore
-    ctx.Response.Body <- new MemoryStream()
-    let expected = "test"
-
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
-
-    match result with
-    | None -> assertFailf "Result was expected to be %s" expected
-    | Some ctx ->
-        let body = getBody ctx
-        Assert.Equal(expected, body)
+// ``GET "/api/test" returns "test"``
 
 [<Fact>]
 let ``GET "/api/v2/users" returns "users v2"`` () =
@@ -696,16 +651,15 @@ let ``GET "/api/v2/users" returns "users v2"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "users v2"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/api/foo/bar/yadayada" returns "yadayada"`` () =
@@ -727,16 +681,15 @@ let ``GET "/api/foo/bar/yadayada" returns "yadayada"`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "yadayada"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
     | Some ctx ->
         let body = getBody ctx
         Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``GET "/person" returns rendered HTML view`` () =
@@ -767,17 +720,51 @@ let ``GET "/person" returns rendered HTML view`` () =
     ctx.Response.Body <- new MemoryStream()
     let expected = "<!DOCTYPE html><html><head><title>Html Node</title></head><body><p>John Doe is 30 years old.</p></body></html>"
 
-    let result =
+    task {
+        let! result = app next ctx
 
-        app next ctx
-        |> Async.RunSynchronously
+        match result with
+        | None     -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            let body = (getBody ctx).Replace(Environment.NewLine, String.Empty)
+            Assert.Equal(expected, body)
+            Assert.Equal("text/html", ctx.Response |> getContentType)
+    }
 
-    match result with
-    | None     -> assertFailf "Result was expected to be %s" expected
-    | Some ctx ->
-        let body = (getBody ctx).Replace(Environment.NewLine, String.Empty)
-        Assert.Equal(expected, body)
-        Assert.Equal("text/html", ctx.Response |> getContentType)
+[<Fact>]
+let ``GET "/api/test" returns "test"`` () =
+
+    task {
+        let ctx = Substitute.For<HttpContext>()
+
+        let app =
+            GET >=> choose [
+                route "/"    >=> text "Hello World"
+                route "/foo" >=> text "bar"
+                subRoute "/api" (
+                    choose [
+                        route ""       >=> text "api root"
+                        route "/admin" >=> text "admin"
+                        route "/users" >=> text "users" ] )
+                route "/api/test" >=> text "test"
+                setStatusCode 404 >=> text "Not found" ]
+
+        let handler = app next
+
+        ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
+        ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+        ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/test")) |> ignore
+        ctx.Response.Body <- new MemoryStream()
+        let expected = "test"
+    
+        let! result = handler ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/json" returns JSON object`` () =
@@ -808,10 +795,8 @@ let ``Get "/auto" with Accept header of "application/json" returns JSON object``
 
     let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"left ear\",\"nose\"]}"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -819,6 +804,7 @@ let ``Get "/auto" with Accept header of "application/json" returns JSON object``
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("application/json", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/xml; q=0.9, application/json" returns JSON object`` () =
@@ -849,10 +835,8 @@ let ``Get "/auto" with Accept header of "application/xml; q=0.9, application/jso
 
     let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"left ear\",\"nose\"]}"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -860,6 +844,7 @@ let ``Get "/auto" with Accept header of "application/xml; q=0.9, application/jso
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("application/json", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/xml" returns XML object`` () =
@@ -900,10 +885,8 @@ let ``Get "/auto" with Accept header of "application/xml" returns XML object`` (
   </Piercings>
 </Person>"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -911,6 +894,7 @@ let ``Get "/auto" with Accept header of "application/xml" returns XML object`` (
         let body = getBody ctx
         XmlAssert.equals expected body
         Assert.Equal("application/xml", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/xml, application/json" returns XML object`` () =
@@ -951,10 +935,8 @@ let ``Get "/auto" with Accept header of "application/xml, application/json" retu
   </Piercings>
 </Person>"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -962,6 +944,7 @@ let ``Get "/auto" with Accept header of "application/xml, application/json" retu
         let body = getBody ctx
         XmlAssert.equals expected body
         Assert.Equal("application/xml", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/json, application/xml" returns JSON object`` () =
@@ -992,10 +975,8 @@ let ``Get "/auto" with Accept header of "application/json, application/xml" retu
 
     let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"ear\",\"nose\"]}"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -1003,6 +984,7 @@ let ``Get "/auto" with Accept header of "application/json, application/xml" retu
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("application/json", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xml" returns XML object`` () =
@@ -1043,10 +1025,8 @@ let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xm
   </Piercings>
 </Person>"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -1054,6 +1034,7 @@ let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xm
         let body = getBody ctx
         XmlAssert.equals expected body
         Assert.Equal("application/xml", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xml; q=0.6" returns XML object`` () =
@@ -1094,10 +1075,8 @@ let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xm
   </Piercings>
 </Person>"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -1105,6 +1084,7 @@ let ``Get "/auto" with Accept header of "application/json; q=0.5, application/xm
         let body = getBody ctx
         XmlAssert.equals expected body
         Assert.Equal("application/xml", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "text/plain; q=0.7, application/xml; q=0.6" returns text object`` () =
@@ -1139,10 +1119,8 @@ Birth date: 1990-07-12
 Height: 1.85
 Piercings: [|""ear""; ""nose""|]"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -1150,6 +1128,7 @@ Piercings: [|""ear""; ""nose""|]"
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("text/plain", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" with Accept header of "text/html" returns a 406 response`` () =
@@ -1180,10 +1159,8 @@ let ``Get "/auto" with Accept header of "text/html" returns a 406 response`` () 
 
     let expected = "text/html is unacceptable by the server."
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -1192,6 +1169,7 @@ let ``Get "/auto" with Accept header of "text/html" returns a 406 response`` () 
         Assert.Equal(406, getStatusCode ctx)
         Assert.Equal(expected, body)
         Assert.Equal("text/plain", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Get "/auto" without an Accept header returns a JSON object`` () =
@@ -1221,10 +1199,8 @@ let ``Get "/auto" without an Accept header returns a JSON object`` () =
 
     let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"ear\",\"nose\"]}"
 
-    let result =
-
-        app next ctx
-        |> Async.RunSynchronously
+    task {
+    let! result = app next ctx
 
     match result with
     | None -> assertFailf "Result was expected to be %s" expected
@@ -1232,6 +1208,7 @@ let ``Get "/auto" without an Accept header returns a JSON object`` () =
         let body = getBody ctx
         Assert.Equal(expected, body)
         Assert.Equal("application/json", ctx.Response |> getContentType)
+    }
 
 [<Fact>]
 let ``Warbler function should execute inner function each time`` () =
@@ -1246,40 +1223,31 @@ let ``Warbler function should execute inner function each time`` () =
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo")) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let result1 =
+    task {
 
-        app next ctx
-        |> Async.RunSynchronously
-        |> (fun res -> getBody res.Value)
+        let! res1 = app next ctx 
+        let result1 = getBody res1.Value
 
-    ctx.Response.Body <- new MemoryStream()
+        ctx.Response.Body <- new MemoryStream()
 
-    let result2 =
+        let! res2 = app next ctx
+        let result2 = getBody res2.Value
 
-        app next ctx
-        |> Async.RunSynchronously
-        |> (fun res -> getBody res.Value)
+        Assert.Equal(result1, result2)
 
-    Assert.Equal(result1, result2)
+        ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo2")) |> ignore
+        ctx.Response.Body <- new MemoryStream()
 
-    ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo2")) |> ignore
-    ctx.Response.Body <- new MemoryStream()
+        let! res3 = app next ctx 
+        let result3 = getBody res3.Value
 
-    let result3 =
+        ctx.Response.Body <- new MemoryStream()
 
-        app next ctx
-        |> Async.RunSynchronously
-        |> (fun res -> getBody res.Value)
+        let! res4 = app next ctx 
+        let result4 = getBody res4.Value
 
-    ctx.Response.Body <- new MemoryStream()
-
-    let result4 =
-
-        app next ctx
-        |> Async.RunSynchronously
-        |> (fun res -> getBody res.Value)
-
-    Assert.False(result3.Equals result4)
+        Assert.False(result3.Equals result4)
+    }
 
 [<Fact>]
 let ``GET "/redirect" redirect to "/" `` () =
@@ -1293,15 +1261,14 @@ let ``GET "/redirect" redirect to "/" `` () =
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/redirect")) |> ignore
 
-    let result =
+    task {
+        let! result = app next ctx
 
-        app next ctx
-        |> Async.RunSynchronously
+        match result with
+        | None     -> assertFail "It was expected that the request would be redirected"
+        | Some ctx -> ctx.Response.Received().Redirect("/", false)
 
-    match result with
-    | None     -> assertFail "It was expected that the request would be redirected"
-    | Some ctx -> ctx.Response.Received().Redirect("/", false)
-
+    }
 
 [<Fact>]
 let ``POST "/redirect" redirect to "/" `` () =
@@ -1315,14 +1282,13 @@ let ``POST "/redirect" redirect to "/" `` () =
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/redirect")) |> ignore
 
-    let result =
+    task {
+        let! result = app next ctx
 
-        app next ctx
-        |> Async.RunSynchronously
-
-    match result with
-    | None     -> assertFail "It was expected that the request would be redirected"
-    | Some ctx -> ctx.Response.Received().Redirect("/", true)
+        match result with
+        | None     -> assertFail "It was expected that the request would be redirected"
+        | Some ctx -> ctx.Response.Received().Redirect("/", true)
+    }
 
 type RouteBind = { Foo : string; Bar : int; Id : Guid }
 
@@ -1333,13 +1299,12 @@ let ``GET "/{foo}/{bar}" returns Hello World``() =
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/1/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
     ctx.Response.Body <- new MemoryStream()
-    let result =
+    task {
+        let! result = app next ctx
 
-        app next ctx
-        |> Async.RunSynchronously
-
-    match result with
-    | None     -> assertFail "It was expected that the result would be Hello 1"
-    | Some ctx ->
-        let body = getBody ctx
-        Assert.Equal("Hello 1 f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
+        match result with
+        | None     -> assertFail "It was expected that the result would be Hello 1"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal("Hello 1 f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
+    }


### PR DESCRIPTION
As discussed in issue #53, I have updated new continuation format to use task {} rather than async {}.

This version allows binding to both `Task<'T>` & plain `Task` without the need of type assertions thanks to [TaskBuilder](https://github.com/rspeele/TaskBuilder.fs) based on @rspeele implementation that uses Extention methods & task-like member constraints for seamless overloading. I have emailed Robert and he is happy for us to use in Giraffe based on his implementation (I have removed taskbuilder context-sensitive related code given asp.net core does no context switching and is purely context-insensitive).

This TaskBuilder approach should also allow the use of ValueTask<'T> in the future to remove scheduling of final pipeline completion Tasks of Some/None but for now, Task should be fine.

Due to change in execution path logic for `subRoutes`, I had to update `handlerWithRootedPath` to test returned value (Some/None), such that it would strip the current subpath out of the `routekey` if it had failed and needed to continue. The completed Task that provides this option result is passed completed into the pipeline rather than rescheduling a new task as the binder will pick up that it is already completed on next continuation and not waste scheduling. My next PR for new Router will provide a more direct performant alternative for sub-routing. 

