### PR TITLE
add async bind overload

### DIFF
--- a/src/Giraffe/Tasks.fs
+++ b/src/Giraffe/Tasks.fs
@@ -262,6 +262,11 @@ module TaskBuilder =
         member inline __.Bind(task : 'a Task, continuation : 'a -> 'b Step) : 'b Step =
             bindTaskConfigureFalse task continuation
 
+        // Async overload bind
+        member inline __.Bind(work : 'a Async, continuation : 'a -> 'b Step) : 'b Step =
+            let task = Async.StartAsTask work 
+            bindTaskConfigureFalse task continuation
+
 // Don't warn about our use of the "obsolete" module we just defined (see notes at start of file).
 #nowarn "44"
 


### PR DESCRIPTION
I have added basic async bind overload to `task {}` so people can use async methods in the task builder.

I have also added a basic test that binds to `Async.sleep` to confirm async bind working