### PR TITLE
fix warbler after api change

### DIFF
--- a/samples/SampleApp/SampleApp/Program.fs
+++ b/samples/SampleApp/SampleApp/Program.fs
@@ -124,7 +124,7 @@ let webApp =
                 route  "/fileupload" >=> razorHtmlView "FileUpload" ""
                 route  "/person"     >=> (personView { Name = "Html Node" } |> renderHtml)
                 route  "/once"       >=> (time() |> text)
-                route  "/everytime"  >=> warbler (fun _ -> (time() |> text))
+                route  "/everytime"  >=> warbler (fun _ _ -> (time() |> text))
             ]
         POST >=>
             choose [

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -26,7 +26,7 @@ type ErrorHandler   = exn -> ILogger -> HttpHandler
 /// Globally useful functions
 /// ---------------------------
 
-let inline warbler f a = f a a
+let inline warbler f a b = (f a b) a b
 
 let shortCircuit : HttpFuncResult = Task.FromResult None
 


### PR DESCRIPTION
`warbler` didn't execute every time as it was missing the second argument for the new `HttpHandler` signature. Tested this out in the sample app and it works as expected now.

What I'm not sure of is why the exist unit test still passed and what would be a good way to re-write so it fails when expected.