### PR TITLE
Fix readFileAsString disposing of resources before completion.

### DIFF
--- a/src/Giraffe/Common.fs
+++ b/src/Giraffe/Common.fs
@@ -16,10 +16,11 @@ let inline isNotNull x = isNull x |> not
 let inline strOption (str : string) =
     if String.IsNullOrEmpty str then None else Some str
 
-let readFileAsString (filePath : string) =
+let readFileAsString (filePath : string) = task {
     use stream = new FileStream(filePath, FileMode.Open)
     use reader = new StreamReader(stream)
-    reader.ReadToEndAsync()
+    return! reader.ReadToEndAsync()
+}
 
 /// ---------------------------
 /// Serializers


### PR DESCRIPTION
readFileAsString was disposing of the stream and the reader before the task completed. This PR fixes that by wrapping the whole thing in a Task CE. (See issue #88)