### PR TITLE
[RFC] Add ability to customize JSON serializer settings

### DIFF
--- a/src/Giraffe/Common.fs
+++ b/src/Giraffe/Common.fs
@@ -27,7 +27,11 @@ let readFileAsString (filePath : string) =
 /// Serializers
 /// ---------------------------
 
-let inline serializeJson x = JsonConvert.SerializeObject x
+let inline serializeJson (serializer : JsonSerializer) x =
+    use stream = new MemoryStream()
+    use writer = new StreamWriter(stream)
+    serializer.Serialize(writer, x)
+    stream.ToString()
 
 let inline deserializeJson<'T> str = JsonConvert.DeserializeObject<'T> str
 

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -293,7 +293,7 @@ let text (str : string) : HttpHandler =
     setHttpHeader "Content-Type" "text/plain"
     >=> setBodyAsString str
 
-let private makeJsonHandler serializer (dataObj : obj) : HttpHandler =
+let makeJsonHandler serializer (dataObj : obj) : HttpHandler =
     setHttpHeader "Content-Type" "application/json"
     >=> setBodyAsString (serializeJson serializer dataObj)
 
@@ -301,11 +301,6 @@ let private makeJsonHandler serializer (dataObj : obj) : HttpHandler =
 /// It also sets the HTTP header Content-Type: application/json and sets the Content-Length header accordingly.
 let json (dataObj : obj) : HttpHandler =
     makeJsonHandler (JsonSerializer.CreateDefault()) dataObj
-
-/// Serializes an object to JSON and writes it to the body of the HTTP response.
-/// It also sets the HTTP header Content-Type: application/json and sets the Content-Length header accordingly.
-let customJson (settings : JsonSerializerSettings) (dataObj : obj) : HttpHandler =
-    makeJsonHandler (JsonSerializer.Create(settings)) dataObj
 
 /// Serializes an object to XML and writes it to the body of the HTTP response.
 /// It also sets the HTTP header Content-Type: application/xml and sets the Content-Length header accordingly.

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -12,6 +12,7 @@ open Microsoft.Extensions.Primitives
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open FSharp.Core.Printf
+open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open Giraffe.Tasks
 open Giraffe.Common
@@ -292,11 +293,19 @@ let text (str : string) : HttpHandler =
     setHttpHeader "Content-Type" "text/plain"
     >=> setBodyAsString str
 
+let private makeJsonHandler serializer (dataObj : obj) : HttpHandler =
+    setHttpHeader "Content-Type" "application/json"
+    >=> setBodyAsString (serializeJson serializer dataObj)
+
 /// Serializes an object to JSON and writes it to the body of the HTTP response.
 /// It also sets the HTTP header Content-Type: application/json and sets the Content-Length header accordingly.
 let json (dataObj : obj) : HttpHandler =
-    setHttpHeader "Content-Type" "application/json"
-    >=> setBodyAsString (serializeJson dataObj)
+    makeJsonHandler (JsonSerializer.CreateDefault()) dataObj
+
+/// Serializes an object to JSON and writes it to the body of the HTTP response.
+/// It also sets the HTTP header Content-Type: application/json and sets the Content-Length header accordingly.
+let customJson (settings : JsonSerializerSettings) (dataObj : obj) : HttpHandler =
+    makeJsonHandler (JsonSerializer.Create(settings)) dataObj
 
 /// Serializes an object to XML and writes it to the body of the HTTP response.
 /// It also sets the HTTP header Content-Type: application/xml and sets the Content-Length header accordingly.


### PR DESCRIPTION
Currently the `json` HTTP handler will always use the default JSON serializer settings.

It is possible to change them by directly modifying `JsonConvert.DefaultSettings`, but since this will change the settings globally there are some cases where this is undesirable. It would be much better to be able to customize the serializer settings on a case-by-case basis.

From an API standpoint, do we want to make this the default for `json`? Or should there be something like a `customJson` that someone can use if they want to opt-in to this functionality?
