### PR TITLE
Only get sub path if it is in the path

### DIFF
--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -46,9 +46,9 @@ let private getSavedSubPath (ctx : HttpContext) =
 
 let private getPath (ctx : HttpContext) =
     match getSavedSubPath ctx with
-    | Some p -> ctx.Request.Path.ToString().[p.Length..]
-    | None   -> ctx.Request.Path.ToString()
-
+    | Some p when ctx.Request.Path.Value.Contains p -> ctx.Request.Path.Value.[p.Length..]
+    | _   -> ctx.Request.Path.Value
+    
 let private handlerWithRootedPath (path : string) (handler : HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         task {


### PR DESCRIPTION
When an exception is thrown in a subroute, and this middleware is used:

[ExceptionHandlerMiddleware](https://github.com/aspnet/Diagnostics/blob/rel/2.0.1/src/Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerMiddleware.cs#L59)

`context.Request.Path` is set to `_options.ExceptionHandlingPath`, so `System.IndexOutOfRangeException: Index was outside the bounds of the array` was thrown on the subsequent call to `getPath`