### PR TITLE
Discarded trailing slashes in the path when binding to a route.

### DIFF
--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -213,13 +213,14 @@ let routeCif (path : StringFormat<_, 'T>) (routeHandler : 'T -> HttpHandler) : H
             | Some args -> routeHandler args next ctx
 
 /// Filters an incoming HTTP request based on the request path (case insensitive).
+/// The filter ignores any trailing slashes on the path.
 /// The parameters from the string will be used to create an instance of 'T
 /// and subsequently passed into the supplied routeHandler.
 let routeBind<'T> (route: string) (routeHandler : 'T -> HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         let pattern = route.Replace("{", "(?<").Replace("}", ">.+)") |> sprintf "^%s$"
         let regex = Regex(pattern, RegexOptions.IgnoreCase)
-        let mtch = regex.Match ctx.Request.Path.Value
+        let mtch = regex.Match (ctx.Request.Path.Value.TrimEnd('/'))
         match mtch.Success with
         | true ->
             let groups = mtch.Groups


### PR DESCRIPTION
For paths that end with a slash, the current implementation interprets that slash as being part of the value of the the last segment in the path. This is not what one would expect, given that slashes are path segment delimiters.

Incidentally, If the binding of the last member is done to a non-string property on a type, the binding throws an exception.

This PR (attempts to, at least) change that, so the binding becomes robust with respect to trailing slashes.

I hope you find this useful - otherwise, please let me know :) 