### PR TITLE
Fixed some typos in an example page

### DIFF
--- a/samples/IdentityApp/IdentityApp/Program.fs
+++ b/samples/IdentityApp/IdentityApp/Program.fs
@@ -30,7 +30,7 @@ let masterPage (pageTitle : string) (content : XmlNode list) =
     html [] [
         head [] [
             title [] [ encodedText pageTitle ]
-            style [] [ rawText "label { display: inline-box; widht: 80px; }" ]
+            style [] [ rawText "label { display: inline-block; width: 80px; }" ]
         ]
         body [] [
             h1 [] [ encodedText pageTitle ]


### PR DESCRIPTION
The CSS property `display` has no value `inline-box`. I think you meant `inline-block`.