### PR TITLE
UseGiraffeErrorHandler chaining support

### DIFF
--- a/samples/IdentityApp/IdentityApp/Program.fs
+++ b/samples/IdentityApp/IdentityApp/Program.fs
@@ -201,12 +201,12 @@ let errorHandler (ex : Exception) (logger : ILogger) =
 
 let configureCors (builder : CorsPolicyBuilder) =
     builder.WithOrigins("http://localhost:8080").AllowAnyMethod().AllowAnyHeader() |> ignore
-    
+
 let configureApp (app : IApplicationBuilder) =
-    app.UseCors configureCors |> ignore
-    app.UseGiraffeErrorHandler errorHandler
-    app.UseAuthentication() |> ignore
-    app.UseGiraffe webApp
+    app.UseCors(configureCors)
+        .UseGiraffeErrorHandler(errorHandler)
+        .UseAuthentication()
+        .UseGiraffe webApp
 
 let configureServices (services : IServiceCollection) =
     // Configure InMemory Db for sample application

--- a/samples/JwtApp/JwtApp/Program.fs
+++ b/samples/JwtApp/JwtApp/Program.fs
@@ -19,7 +19,7 @@ open Giraffe.Middleware
 // Web app
 // ---------------------------------
 
-type SimpleClaim = { Type: string; Value: string } 
+type SimpleClaim = { Type: string; Value: string }
 
 let authorize =
     requiresAuthentication (challenge JwtBearerDefaults.AuthenticationScheme)
@@ -29,13 +29,13 @@ let greet =
         let claim = ctx.User.FindFirst "name"
         let name = claim.Value
         text ("Hello " + name) next ctx
-    
+
 let showClaims =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         let claims = ctx.User.Claims
         let simpleClaims = Seq.map (fun (i : Claim) -> {Type = i.Type; Value = i.Value}) claims
         json simpleClaims next ctx
-    
+
 let webApp =
     choose [
         GET >=>
@@ -59,10 +59,10 @@ let errorHandler (ex : Exception) (logger : ILogger) =
 // ---------------------------------
 
 let configureApp (app : IApplicationBuilder) =
-    app.UseAuthentication() |> ignore
-    app.UseGiraffeErrorHandler errorHandler
-    app.UseStaticFiles() |> ignore
-    app.UseGiraffe webApp
+    app.UseAuthentication()
+        .UseGiraffeErrorHandler(errorHandler)
+        .UseStaticFiles()
+        .UseGiraffe webApp
 
 let authenticationOptions (o : AuthenticationOptions) =
     o.DefaultAuthenticateScheme <- JwtBearerDefaults.AuthenticationScheme

--- a/samples/SampleApp/SampleApp/Program.fs
+++ b/samples/SampleApp/SampleApp/Program.fs
@@ -156,10 +156,10 @@ let cookieAuth (o : CookieAuthenticationOptions) =
         o.ExpireTimeSpan      <- TimeSpan.FromDays 7.0
 
 let configureApp (app : IApplicationBuilder) =
-    app.UseGiraffeErrorHandler errorHandler
-    app.UseStaticFiles() |> ignore
-    app.UseAuthentication() |> ignore
-    app.UseGiraffe webApp
+    app.UseGiraffeErrorHandler(errorHandler)
+        .UseStaticFiles()
+        .UseAuthentication()
+        .UseGiraffe webApp
 
 let configureServices (services : IServiceCollection) =
     let sp  = services.BuildServiceProvider()

--- a/src/Giraffe/Middleware.fs
+++ b/src/Giraffe/Middleware.fs
@@ -83,4 +83,3 @@ type IApplicationBuilder with
 
     member this.UseGiraffeErrorHandler (handler : ErrorHandler) =
         this.UseMiddleware<GiraffeErrorHandlerMiddleware> handler
-        |> ignore


### PR DESCRIPTION
UseGiraffeErrorHandler ApplicationBuilder extension modified (ignore removed) to support chaining since it should probably never be the last middleware in the pipeline.

```fsharp
app.UseCors(configureCors)
    .UseGiraffeErrorHandler(errorHandler)
    .UseAuthentication()
    .UseGiraffe webApp
```
vs
```fsharp
app.UseCors configureCors |> ignore
app.UseGiraffeErrorHandler errorHandler
app.UseAuthentication() |> ignore
app.UseGiraffe webApp
```