### PR TITLE
Fix template referencing wrong packages

### DIFF
--- a/template/content/_AppName.fsproj
+++ b/template/content/_AppName.fsproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.*" />
-    <PackageReference Include="Giraffe" Version="0.1.0-beta-110" />
-    <PackageReference Include="Giraffe.Razor" Version="0.1.0-beta-200" />
+    <PackageReference Include="Giraffe" Version="0.1.0-beta-200" />
+    <PackageReference Include="Giraffe.Razor" Version="0.1.0-beta-100" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix problem with the template using outdated Giraffe version 0.1.0-beta-110 and nonexistent Giraffe.Razor version 0.1.0-beta-200