### PR TITLE
Modified regex generation so that tokens are identified at the end of the request path.

### DIFF
--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -217,7 +217,7 @@ let routeCif (path : StringFormat<_, 'T>) (routeHandler : 'T -> HttpHandler) : H
 /// and subsequently passed into the supplied routeHandler.
 let routeBind<'T> (route: string) (routeHandler : 'T -> HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        let pattern = route.Replace("{", "(?<").Replace("}", ">[^/\n]+)") |> sprintf "^%s$"
+        let pattern = route.Replace("{", "(?<").Replace("}", ">[^/\n]+)") |> sprintf "%s$"
         let regex = Regex(pattern, RegexOptions.IgnoreCase)
         let mtch = regex.Match ctx.Request.Path.Value
         match mtch.Success with

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -1437,3 +1437,55 @@ let ``GET "/{foo}/{bar}/{id}" returns Hello 4 f40580b1-d55b-4fe2-b6fb-ca4f90749a
             let body = getBody ctx
             Assert.Equal("Hello 4 f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
     }
+
+[<Fact>]
+let ``GET "/api/{foo}/{bar}/{id}" returns Hello 1 f40580b1-d55b-4fe2-b6fb-ca4f90749a9d``() =
+    let ctx = Substitute.For<HttpContext>()
+    let app = GET >=> routeBind<RouteBind> "/api/{foo}/{bar}/{id}" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/Hello/1/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None     -> assertFail "It was expected that the result would be Hello 1"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal("Hello 1 f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
+    }
+
+type RouteBindId = { Id : Guid }
+[<Fact>]
+let ``GET "/api/{id}" returns f40580b1-d55b-4fe2-b6fb-ca4f90749a9d``() =
+    let ctx = Substitute.For<HttpContext>()
+    let app = GET >=> routeBind<RouteBindId> "/api/{id}" (fun m -> sprintf "%O" m.Id |> text)
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None     -> assertFail "It was expected that the result would be f40580b1-d55b-4fe2-b6fb-ca4f90749a9d"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal("f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
+    }
+
+[<Fact>]
+let ``GET "/api/{id}/" returns f40580b1-d55b-4fe2-b6fb-ca4f90749a9d``() =
+    let ctx = Substitute.For<HttpContext>()
+    let app = GET >=> routeBind<RouteBindId> "/api/{id}(/?)" (fun m -> sprintf "%O" m.Id |> text)
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d/")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None     -> assertFail "It was expected that the result would be f40580b1-d55b-4fe2-b6fb-ca4f90749a9d"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal("f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
+    }


### PR DESCRIPTION
Regex generation only worked for paths that started and ended with tokens (/{foo}/{bar}/{id} and not for paths /api/{foo}/{bar}/{id}.