### PR TITLE
Use camel-case for property values returned as JSON

### DIFF
--- a/src/Giraffe/Common.fs
+++ b/src/Giraffe/Common.fs
@@ -6,6 +6,7 @@ open System.Text
 open System.Xml
 open System.Xml.Serialization
 open Newtonsoft.Json
+open Newtonsoft.Json.Serialization
 
 /// ---------------------------
 /// Helper functions
@@ -27,7 +28,10 @@ let readFileAsString (filePath : string) =
 /// Serializers
 /// ---------------------------
 
-let inline serializeJson x = JsonConvert.SerializeObject x
+let settings = JsonSerializerSettings()
+settings.ContractResolver <- CamelCasePropertyNamesContractResolver()
+
+let inline serializeJson x = JsonConvert.SerializeObject(x, settings)
 
 let inline deserializeJson<'T> str = JsonConvert.DeserializeObject<'T> str
 

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -156,7 +156,7 @@ let ``GET "/json" returns json object`` () =
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/json")) |> ignore
     ctx.Response.Body <- new MemoryStream()
-    let expected = "{\"Foo\":\"john\",\"Bar\":\"doe\",\"Age\":30}"
+    let expected = "{\"foo\":\"john\",\"bar\":\"doe\",\"age\":30}"
 
     task {
         let! result = app next ctx
@@ -837,7 +837,7 @@ let ``Get "/auto" with Accept header of "application/json" returns JSON object``
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"left ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"left ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx
@@ -877,7 +877,7 @@ let ``Get "/auto" with Accept header of "application/xml; q=0.9, application/jso
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"left ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"left ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx
@@ -1017,7 +1017,7 @@ let ``Get "/auto" with Accept header of "application/json, application/xml" retu
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx
@@ -1241,7 +1241,7 @@ let ``Get "/auto" without an Accept header returns a JSON object`` () =
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx

--- a/tests/Giraffe.Tests/TokenRouterTests.fs
+++ b/tests/Giraffe.Tests/TokenRouterTests.fs
@@ -156,7 +156,7 @@ let ``GET "/json" returns json object`` () =
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/json")) |> ignore
     ctx.Response.Body <- new MemoryStream()
-    let expected = "{\"Foo\":\"john\",\"Bar\":\"doe\",\"Age\":30}"
+    let expected = "{\"foo\":\"john\",\"bar\":\"doe\",\"age\":30}"
 
     task {
         let! result = app next ctx
@@ -821,7 +821,7 @@ let ``Get "/auto" with Accept header of "application/json" returns JSON object``
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"left ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"left ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx
@@ -861,7 +861,7 @@ let ``Get "/auto" with Accept header of "application/xml; q=0.9, application/jso
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"left ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"left ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx
@@ -1001,7 +1001,7 @@ let ``Get "/auto" with Accept header of "application/json, application/xml" retu
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx
@@ -1225,7 +1225,7 @@ let ``Get "/auto" without an Accept header returns a JSON object`` () =
     ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
     ctx.Response.Body <- new MemoryStream()
 
-    let expected = "{\"FirstName\":\"John\",\"LastName\":\"Doe\",\"BirthDate\":\"1990-07-12T00:00:00\",\"Height\":1.85,\"Piercings\":[\"ear\",\"nose\"]}"
+    let expected = "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"birthDate\":\"1990-07-12T00:00:00\",\"height\":1.85,\"piercings\":[\"ear\",\"nose\"]}"
 
     task {
         let! result = app next ctx


### PR DESCRIPTION
Returned JSON should be camel-cased as this is the standard format and what is expected.