### PR TITLE
Use synchronous .ReadToEnd() in .ReadBodyFromRequest() fixes issue #136

### DIFF
--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -55,17 +55,17 @@ type HttpContext with
     member this.ReadBodyFromRequest() =
         let body = this.Request.Body
         use reader = new StreamReader(body, true)
-        reader.ReadToEndAsync()
+        reader.ReadToEnd()
 
     member this.BindJson<'T>() =
         task {
-            let! body = this.ReadBodyFromRequest()
+            let body = this.ReadBodyFromRequest()
             return deserializeJson<'T> body
         }
 
     member this.BindXml<'T>() =
         task {
-            let! body = this.ReadBodyFromRequest()
+            let body = this.ReadBodyFromRequest()
             return deserializeXml<'T> body
         }
 


### PR DESCRIPTION
May be a quick fix but for now, but it works.