### PR TITLE
fix StringFormat to PrintfFormat as bug in type inference

### DIFF
--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -38,7 +38,7 @@ let convertToRegexPatternAndFormatChars (formatString : string) =
     |> convert
     |> (fun (pattern, formatChars) -> sprintf "^%s$" pattern, formatChars)
 
-let tryMatchInput (format : StringFormat<_, 'T>) (input : string) (ignoreCase : bool) =
+let tryMatchInput (format : PrintfFormat<_,_,_,_, 'T>) (input : string) (ignoreCase : bool) =
     try
         let pattern, formatChars = 
             format.Value

--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -12,7 +12,7 @@ let formatStringMap =
     // ----------------------------------------------------------
         'b', ("(?i:(true|false)){1}",   bool.Parse >> box)  // bool
         'c', ("(.{1})",                 char       >> box)  // char
-        's', ("(.+)",                                 box)  // string
+        's', ("(.+)",                   Net.WebUtility.UrlDecode >> box)  // string
         'i', ("(-?\d+)",                int32      >> box)  // int
         'd', ("(-?\d+)",                int64      >> box)  // int64
         'f', ("(-?\d+\.{1}\d+)",        float      >> box)  // float
@@ -64,7 +64,7 @@ let tryMatchInput (format : PrintfFormat<_,_,_,_, 'T>) (input : string) (ignoreC
                 (groups, formatChars)
                 ||> Seq.map2 (fun g c -> 
                     let _, parser   = formatStringMap.[c]
-                    let value       = parser g.Value
+                    let value       = parser g.Value  
                     value)
                 |> Seq.toArray
 

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -59,13 +59,11 @@ type HttpContext with
         reader.ReadToEndAsync()
 
     member this.BindJson<'T>() =
-        task {
             let body = this.Request.Body
             use sr = new StreamReader(body, true)
             use jr = new JsonTextReader(sr)
             let serializer = JsonSerializer()
-            return serializer.Deserialize<'T>(jr);
-        }
+            serializer.Deserialize<'T>(jr)
 
     member this.BindXml<'T>() =
         task {

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -57,14 +57,13 @@ type HttpContext with
         let body = this.Request.Body
         use reader = new StreamReader(body, true)
         reader.ReadToEndAsync()
-
-    member this.BindJson<'T>() =
+    member this.BindJson<'T>() = task {
             let body = this.Request.Body
             use sr = new StreamReader(body, true)
             use jr = new JsonTextReader(sr)
             let serializer = JsonSerializer()
-            serializer.Deserialize<'T>(jr)
-
+            return serializer.Deserialize<'T>(jr)
+    }
     member this.BindXml<'T>() =
         task {
             let! body = this.ReadBodyFromRequest()

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -11,6 +11,7 @@ open Microsoft.Extensions.Logging
 open Microsoft.FSharp.Reflection
 open Microsoft.Net.Http.Headers
 open Giraffe.Common
+open Newtonsoft.Json
 
 type HttpContext with
 
@@ -59,8 +60,11 @@ type HttpContext with
 
     member this.BindJson<'T>() =
         task {
-            let! body = this.ReadBodyFromRequest()
-            return deserializeJson<'T> body
+            let body = this.Request.Body
+            use sr = new StreamReader(body, true)
+            use jr = new JsonTextReader(sr)
+            let serializer = JsonSerializer()
+            return serializer.Deserialize<'T>(jr);
         }
 
     member this.BindXml<'T>() =

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -70,11 +70,11 @@ let private handlerWithRootedPath (path : string) (handler : HttpHandler) : Http
 
 /// Combines two HttpHandler functions into one.
 let compose (handler1 : HttpHandler) (handler2 : HttpHandler) : HttpHandler =
-    fun (next : HttpFunc) ->
-        let func = next |> handler2 |> handler1
+    fun (final : HttpFunc) ->
+        let func = final |> handler2 |> handler1
         fun (ctx : HttpContext) ->
             match ctx.Response.HasStarted with
-            | true  -> next ctx
+            | true  -> final ctx
             | false -> func ctx
 
 /// Combines two HttpHandler functions into one.
@@ -188,7 +188,7 @@ let route (path : string) : HttpHandler =
 /// Filters an incoming HTTP request based on the request path (case sensitive).
 /// The arguments from the format string will be automatically resolved when the
 /// route matches and subsequently passed into the supplied routeHandler.
-let routef (path : StringFormat<_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
+let routef (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         tryMatchInput path (getPath ctx) false
         |> function
@@ -205,7 +205,7 @@ let routeCi (path : string) : HttpHandler =
 /// Filters an incoming HTTP request based on the request path (case insensitive).
 /// The arguments from the format string will be automatically resolved when the
 /// route matches and subsequently passed into the supplied routeHandler.
-let routeCif (path : StringFormat<_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
+let routeCif (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         tryMatchInput path (getPath ctx) true
         |> function

--- a/src/Giraffe/TokenRouter.fs
+++ b/src/Giraffe/TokenRouter.fs
@@ -269,13 +269,13 @@ let route (path:string) (fn:HttpHandler) (root:Node) =
 ///**Description**
 /// Matches and parses url values from a route using `printf` string formatting, results are passes to function as tuple.
 ///**Parameters**
-///  * `path` : `StringFormat<'a,'T>` - the route to match & parse using wildcard format of `printf`
+///  * `path` : `PrintfFormat<_,_,_,_,'T>` - the route to match & parse using wildcard format of `printf`
 ///  * `fn` : `'T -> HttpHandler` - function that accepts the parsed tuple value and returns HttpHandler
 ///
 ///**Output Type**
 ///  * `parent` : `Node` - This parameter is applied by `router`, and is ommitted when building api such that function is partially applied fn
 ///  * `Node`
-let routef (path : StringFormat<_,'T>) (fn:'T -> HttpHandler) (root:Node)=
+let routef (path : PrintfFormat<_,_,_,_,'T>) (fn:'T -> HttpHandler) (root:Node)=
 // parsing route that iterates down nodes, parses, and then continues down further notes if needed
     let last = path.Value.Length - 1
 


### PR DESCRIPTION
This is urgent fix needed as users reporting routef handler not inferring types correctly and defaulting to obj when uncertain. there is a bug in StringFormat<_,'T> but changing to PrintfFormat<_,_,_,_,'T> gets rid of this inference bug