### PR TITLE
Changed base tag to voidTag

### DIFF
--- a/src/Giraffe/XmlViewEngine.fs
+++ b/src/Giraffe/XmlViewEngine.fs
@@ -68,7 +68,7 @@ let comment     (content : string) = rawText (sprintf "<!-- %s -->" content)
 let html       = tag "html"
 
 /// Document metadata
-let ``base``   = tag "base"
+let ``base``   = voidTag "base"
 let head       = tag "head"
 let link attr  = voidTag "link" attr
 let meta attr  = voidTag "meta" attr


### PR DESCRIPTION
According to mdn,the `base` tag is an empty one.
See https://developer.mozilla.org/nl/docs/Web/HTML/Element/base