### PR TITLE
Fix Unable to resolve Cors service Error

### DIFF
--- a/samples/IdentityApp/IdentityApp/Program.fs
+++ b/samples/IdentityApp/IdentityApp/Program.fs
@@ -248,7 +248,7 @@ let configureServices (services : IServiceCollection) =
         ) |> ignore
 
     // Enable CORS
-    services.AddCors |> ignore
+    services.AddCors() |> ignore
 
 let configureLogging (builder : ILoggingBuilder) =
     let filter (l : LogLevel) = l.Equals LogLevel.Error


### PR DESCRIPTION
Cors service is not properly enabled without the the parens. This fixes this error: Unhandled Exception: System.InvalidOperationException: Unable to resolve service for type 'Microsoft.AspNetCore.Cors.Infrastructure.ICorsService' while attempting to activate 'Microsoft.AspNetCore.Cors.Infrastructure.CorsMiddleware'.